### PR TITLE
Fixes an array-out-of-bounds failure in XSalsa decrypt

### DIFF
--- a/Chaos.NaCl.Tests/XSalsa20Poly1305Tests.cs
+++ b/Chaos.NaCl.Tests/XSalsa20Poly1305Tests.cs
@@ -126,5 +126,19 @@ namespace Chaos.NaCl.Tests
             var plaintextActual = XSalsa20Poly1305.TryDecrypt(new byte[15], _key, _nonce);
             Assert.AreEqual(null, plaintextActual);
         }
+
+        // Tests for a bug in Decrypt when using short input messages.
+        [TestMethod]
+        public void TestShortMessageRoundTrip() {
+            var plainTextOrig = "Can you read this?";
+            byte[] nonce = new byte[XSalsa20Poly1305.NonceSizeInBytes];
+            byte[] key = new byte[XSalsa20Poly1305.KeySizeInBytes];
+
+            var plainTextBytes = System.Text.Encoding.ASCII.GetBytes(plainTextOrig);
+            var cypherText = XSalsa20Poly1305.Encrypt(plainTextBytes, key, nonce);
+            var plainTextByte = XSalsa20Poly1305.TryDecrypt(cypherText, key, nonce);
+            var plainTextResult = System.Text.Encoding.ASCII.GetString(plainTextBytes);
+            Assert.AreEqual(plainTextOrig, plainTextResult);
+        }
     }
 }

--- a/Chaos.NaCl/XSalsa20Poly1305.cs
+++ b/Chaos.NaCl/XSalsa20Poly1305.cs
@@ -153,7 +153,7 @@ namespace Chaos.NaCl
                 ByteIntegerConverter.StoreLittleEndian32(tempBytes, 20, temp.x13);
                 ByteIntegerConverter.StoreLittleEndian32(tempBytes, 24, temp.x14);
                 ByteIntegerConverter.StoreLittleEndian32(tempBytes, 28, temp.x15);
-                int count = Math.Min(32, ciphertextLength);
+                int count = Math.Min(32, ciphertextLength-MacSizeInBytes);
                 for (int i = 0; i < count; i++)
                     plaintext[plaintextOffset + i] = (byte)(ciphertext[16 + ciphertextOffset + i] ^ tempBytes[i]);
             }


### PR DESCRIPTION
I ran into an array-bound exception when sending a short plain text message through. I believe this fix is correct, but I am still getting up-to-speed on the code so it could easily be wrong. The included unit test demonstrates the error on un-patched code.

Related, I have some basic tests for Ed25519.KeyExchange. This is my primary interest in the library in that I want to use Edwards curves for both signing and key exchange. Are there known issues with KeyExchange that basic tests won't tease out?  In short I want to add the box create/open functionality by using KeyExchange to generate a shared secret and pass that secret to XSalsa Encrypt/Decrypt for distributing a symmetric encryption key to multiple parties. If KeyExchange is broken I'll have to find an alternative. But this library is very convenient thus far -- thanks!
