### PR TITLE
Ed25519.KeyExchange generates the same shared keys

### DIFF
--- a/Chaos.NaCl.Tests/Ed25519Tests.cs
+++ b/Chaos.NaCl.Tests/Ed25519Tests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using System.Security.Cryptography;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Chaos.NaCl.Tests
@@ -140,6 +141,23 @@ namespace Chaos.NaCl.Tests
             {
                 Assert.IsFalse(Ed25519.Verify(modifiedSignature.Pad(), message.Pad(), pk.Pad()));
             }
+        }
+
+        [TestMethod]
+        public void KeyExchange()
+        {
+            RNGCryptoServiceProvider rngCryptoServiceProvider = new RNGCryptoServiceProvider();
+            byte[] publicKey0, expandedPrivateKey0;
+            byte[] seed1 = new byte[32];
+            rngCryptoServiceProvider.GetBytes(seed1);
+            Ed25519.KeyPairFromSeed(out publicKey0, out expandedPrivateKey0, seed1);
+            byte[] publicKey1, expandedPrivateKey1;
+            byte[] seed2 = new byte[32];
+            rngCryptoServiceProvider.GetBytes(seed2);
+            Ed25519.KeyPairFromSeed(out publicKey1, out expandedPrivateKey1, seed2);
+            byte[] sharedKey0 = Ed25519.KeyExchange(publicKey1, expandedPrivateKey0);
+            byte[] sharedKey1 = Ed25519.KeyExchange(publicKey0, expandedPrivateKey1);
+            TestHelpers.AssertEqualBytes(sharedKey0, sharedKey1);
         }
     }
 }

--- a/Chaos.NaCl/Chaos.NaCl-Portable.csproj
+++ b/Chaos.NaCl/Chaos.NaCl-Portable.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Internal\Ed25519Ref10\sc_reduce.cs" />
     <Compile Include="Internal\Ed25519Ref10\sign.cs" />
     <Compile Include="Internal\Ed25519Ref10\sqrtm1.cs" />
+    <Compile Include="Internal\Ed25519Ref10\unmultiplied_a.cs" />
     <Compile Include="Internal\InternalAssert.cs" />
     <Compile Include="Internal\Poly1305Donna.cs" />
     <Compile Include="Internal\Salsa\Salsa20.cs" />

--- a/Chaos.NaCl/Chaos.NaCl.csproj
+++ b/Chaos.NaCl/Chaos.NaCl.csproj
@@ -91,12 +91,12 @@
     <Compile Include="Internal\Ed25519Ref10\ge_tobytes.cs" />
     <Compile Include="Internal\Ed25519Ref10\GroupElement.cs" />
     <Compile Include="Internal\Ed25519Ref10\keypair.cs" />
-    <Compile Include="Internal\Ed25519Ref10\unmultiplied_a.cs" />
     <Compile Include="Internal\Ed25519Ref10\open.cs" />
     <Compile Include="Internal\Ed25519Ref10\sc_mul_add.cs" />
     <Compile Include="Internal\Ed25519Ref10\sc_reduce.cs" />
     <Compile Include="Internal\Ed25519Ref10\sign.cs" />
     <Compile Include="Internal\Ed25519Ref10\sqrtm1.cs" />
+    <Compile Include="Internal\Ed25519Ref10\unmultiplied_a.cs" />
     <Compile Include="OneTimeAuth.cs" />
     <Compile Include="Poly1305.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Chaos.NaCl/Chaos.NaCl.csproj
+++ b/Chaos.NaCl/Chaos.NaCl.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Internal\Ed25519Ref10\ge_tobytes.cs" />
     <Compile Include="Internal\Ed25519Ref10\GroupElement.cs" />
     <Compile Include="Internal\Ed25519Ref10\keypair.cs" />
+    <Compile Include="Internal\Ed25519Ref10\unmultiplied_a.cs" />
     <Compile Include="Internal\Ed25519Ref10\open.cs" />
     <Compile Include="Internal\Ed25519Ref10\sc_mul_add.cs" />
     <Compile Include="Internal\Ed25519Ref10\sc_reduce.cs" />

--- a/Chaos.NaCl/Ed25519.cs
+++ b/Chaos.NaCl/Ed25519.cs
@@ -129,14 +129,17 @@ namespace Chaos.NaCl
 				throw new ArgumentException("sharedKey.Count != 32");
 			if (publicKey.Count != 32)
 				throw new ArgumentException("publicKey.Count != 32");
-			if (privateKey.Count != 64)
-				throw new ArgumentException("privateKey.Count != 64");
+			if (privateKey.Count != 64 && privateKey.Count != 32) // seed is enough, full expanded private key is OK
+				throw new ArgumentException("privateKey.Count != 64 && privateKey.Count != 32");
+
+			var ua = new byte[32];
+			Ed25519Operations.unmultiplied_a(ua, 0, privateKey.Array, privateKey.Offset);
 
 			FieldElement montgomeryX, edwardsY, edwardsZ, sharedMontgomeryX;
 			FieldOperations.fe_frombytes(out edwardsY, publicKey.Array, publicKey.Offset);
 			FieldOperations.fe_1(out edwardsZ);
 			MontgomeryCurve25519.EdwardsToMontgomeryX(out montgomeryX, ref edwardsY, ref edwardsZ);
-			MontgomeryOperations.scalarmult(out sharedMontgomeryX, privateKey.Array, privateKey.Offset, ref montgomeryX);
+			MontgomeryOperations.scalarmult(out sharedMontgomeryX, ua, 0, ref montgomeryX);
 			FieldOperations.fe_tobytes(sharedKey.Array, sharedKey.Offset, ref sharedMontgomeryX);
 			MontgomeryCurve25519.KeyExchangeOutputHashNaCl(sharedKey.Array, sharedKey.Offset);
 		}

--- a/Chaos.NaCl/Internal/Ed25519Ref10/unmultiplied_a.cs
+++ b/Chaos.NaCl/Internal/Ed25519Ref10/unmultiplied_a.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Chaos.NaCl.Internal.Ed25519Ref10
+{
+    internal static partial class Ed25519Operations
+    {    
+        public static void unmultiplied_a(byte[] ua, int uaoffset, byte[] seed, int seedoffset)
+        {
+            int i;
+            
+            byte[] h = Sha512.Hash(seed, seedoffset, 32);//ToDo: Remove alloc
+            h[0] &= 248;
+            h[31] &= 63;
+            h[31] |= 64;
+            
+            for (i = 0; i < 32; ++i) ua[uaoffset + i] = h[i];
+            CryptoBytes.Wipe(h);
+        }
+    }
+}


### PR DESCRIPTION
Fix for https://github.com/CodesInChaos/Chaos.NaCl/issues/4

(Note that I don't use Visual Studio and thus no working `Microsoft.VisualStudio.TestTools.UnitTesting`. Consequently, I haven’t actually compiled the test project with the additional test method. Also, I manually added the new file `unmultiplied_a.cs` in the `.csproj` files. I hope I don’t break anything.)
